### PR TITLE
I change the position of the favorite button

### DIFF
--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -14,7 +14,7 @@
 .pin-button {
   position: absolute;
   top: 8px;
-  right: 8px;
+  left: 8px;
   width: 32px;
   height: 32px;
   background-color: rgba(0, 0, 0, 0.6);


### PR DESCRIPTION
**Problem to solve**
The button to bookmark videos was superimposed on the button to mute or volume a video (See first screenshot).


![problem_youtube_pin](https://github.com/user-attachments/assets/52c571f1-08ec-4a9d-a4a1-adc1acaa2457)

**Solution**
 This forces users to bookmark a video before turning up the volume. But a user may want to follow a video without wanting to bookmark it. So I've moved the button to the left, where it won't be superimposed on any other youtube button (see screenshot).


![solution_youtube_pin](https://github.com/user-attachments/assets/9cd3269c-0d22-4766-89ce-648e005469ee)

